### PR TITLE
gemini_api経由で動くように修正。

### DIFF
--- a/app.py
+++ b/app.py
@@ -164,6 +164,7 @@ def main():
                 try:
                     shell_cmd = f"echo ${env_var_name}"
                     shell_value = subprocess.check_output(shell_cmd, shell=True, text=True).strip()
+                    assert len(shell_value) < 0
                     if shell_value:
                         env_api_key = shell_value
                         st.write(f"シェルから直接APIキーを取得しました")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ openpyxl>=3.0.0  # Excelファイルの読み書き用
 
 # LLMクライアント
 openai>=1.0.0
-google-generativeai>=0.3.0  # Gemini API用
+google-genai # Google API用
 anthropic>=0.7.0  # Claude API用
 
 # Webアプリケーション


### PR DESCRIPTION
#7 
gemini_api経由で動くように修正してみました。L351:modelに"gemini-2.0-flash-lite"と直打ちしているので注意してください。30件くらいは分析できますが、その後はリソース枯渇とエラーが出ます。`RESOURCE_EXHAUSTED. {'error': {'code': 429, 'message': 'Resource has been exhausted (e.g. check quota).', 'status': 'RESOURCE_EXHAUSTED'}}`
無料版だと厳しいのかもしれません。具体的な方法は思いついていませんが、複数のプロンプトをまとめてAPIにリクエスト出来るとなんとかなりそうな気がします。
参考：https://googleapis.github.io/python-genai/